### PR TITLE
Multiplied the cropPositionLeft and CropPositionTop values with windo…

### DIFF
--- a/src/ScreenCapture.tsx
+++ b/src/ScreenCapture.tsx
@@ -134,6 +134,8 @@ export default class ScreenCapture extends Component<Props, State> {
     
     cropWidth *= window.devicePixelRatio;
     cropHeigth *= window.devicePixelRatio;
+    cropPositionLeft *= window.devicePixelRatio;
+    cropPositionTop *= window.devicePixelRatio;
 
     this.setState({
       crossHairsTop: e.clientY,


### PR DESCRIPTION
…w.devicePixelRatio

There was an issue which I faced and also read in the issues section in which the clipped image seems to break over a resolution with width of more than 1000. Using  the window.devicePixelRatio ,I was able to solve the problem as I noticed that the  wrong clipped image had wrong initial coordinates in higher resolution but the height and width of the clipped image were correct as window.devicePixelRatio had been applied to them.